### PR TITLE
Fix Telegram code form action

### DIFF
--- a/templates/telegram_code.html
+++ b/templates/telegram_code.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>Enter Telegram Code</h1>
-    <form method="post">
+    <form method="post" action="{{ url_for('telegram_code') }}">
 
         {{ csrf_token() }}
 


### PR DESCRIPTION
## Summary
- set explicit action on the Telegram code form so it posts to `/telegram_code`

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb44f30ac8329a1687a11534155c6